### PR TITLE
Add 'Case' and '(>>=)' FCFs

### DIFF
--- a/src/Fcf.hs
+++ b/src/Fcf.hs
@@ -110,6 +110,14 @@ module Fcf
   , Guard((:=))
   , Otherwise
 
+    -- ** Case splitting
+
+  , Case
+  , Match
+  , type (-->)
+  , Any
+  , Else
+
     -- ** Nat
 
   , type (+)

--- a/src/Fcf.hs
+++ b/src/Fcf.hs
@@ -113,8 +113,9 @@ module Fcf
     -- ** Case splitting
 
   , Case
-  , Match
+  , Match()
   , type (-->)
+  , Is
   , Any
   , Else
 

--- a/src/Fcf/Combinators.hs
+++ b/src/Fcf/Combinators.hs
@@ -29,7 +29,7 @@ import Fcf.Core
 
 -- ** Monadic operations
 
-infixr 1 =<<, <=<
+infixr 1 =<<, >>=, <=<
 infixl 4 <$>, <*>
 
 data Pure :: a -> Exp a
@@ -46,6 +46,9 @@ type instance Eval (Pure3 f x y z) = f x y z
 
 data (=<<) :: (a -> Exp b) -> Exp a -> Exp b
 type instance Eval (k =<< e) = Eval (k (Eval e))
+
+data (>>=) :: Exp a -> (a -> Exp b) -> Exp b
+type instance Eval (e >>= k) = Eval (k (Eval e))
 
 data (<=<) :: (b -> Exp c) -> (a -> Exp b) -> a -> Exp c
 type instance Eval ((f <=< g) x) = Eval (f (Eval (g x)))

--- a/src/Fcf/Data/Bool.hs
+++ b/src/Fcf/Data/Bool.hs
@@ -78,6 +78,7 @@ type instance Eval (Not 'False) = 'True
 data Guarded :: a -> [Guard (a -> Exp Bool) (Exp b)] -> Exp b
 type instance Eval (Guarded x ((p ':= y) ': ys)) =
     Eval (If (Eval (p x)) y (Guarded x ys))
+{-# DEPRECATED Guarded "Use 'Case' instead" #-}
 
 -- | A fancy-looking pair type to use with 'Guarded'.
 data Guard a b = a := b

--- a/src/Fcf/Utils.hs
+++ b/src/Fcf/Utils.hs
@@ -76,9 +76,9 @@ data Match j k
   | Any_ k
   | Else_ (j -> Exp k)
 
--- | Equivalent (limited) of @\\case { .. }@ syntax at value level. Supports
--- matching of exact types ('-->') and final matches for any type ('Any') or
--- for passing type to subcomputation ('Else'). Examples:
+-- | (Limited) equivalent of @\\case { .. }@ syntax. Supports matching of exact
+-- values ('-->') and final matches for any value ('Any') or for passing value
+-- to subcomputation ('Else'). Examples:
 --
 -- @
 -- type BoolToNat = Case

--- a/test/test.hs
+++ b/test/test.hs
@@ -8,17 +8,17 @@ import GHC.TypeLits (Nat)
 import Fcf
 
 type UnitPrefix (n :: Nat) = Eval (Guarded n
-  '[ TyEq 0 ':= Pure ""
-   , TyEq 1 ':= Pure "deci"
-   , TyEq 2 ':= Pure "hecto"
-   , TyEq 3 ':= Pure "kilo"
-   , TyEq 6 ':= Pure "mega"
-   , TyEq 9 ':= Pure "giga"
-   , Otherwise ':= Error "Something else"
-   ])
+  [ TyEq 0 ':= Pure ""
+  , TyEq 1 ':= Pure "deci"
+  , TyEq 2 ':= Pure "hecto"
+  , TyEq 3 ':= Pure "kilo"
+  , TyEq 6 ':= Pure "mega"
+  , TyEq 9 ':= Pure "giga"
+  , Otherwise ':= Error "Something else"
+  ])
 
-type UnitPrefix' = Case [
-    0 --> ""
+type UnitPrefix' = Case
+  [ 0 --> ""
   , 1 --> "deci"
   , 2 --> "hecto"
   , 3 --> "kilo"

--- a/test/test.hs
+++ b/test/test.hs
@@ -17,10 +17,23 @@ type UnitPrefix (n :: Nat) = Eval (Guarded n
    , Otherwise ':= Error "Something else"
    ])
 
+type UnitPrefix' = Case [
+    0 --> ""
+  , 1 --> "deci"
+  , 2 --> "hecto"
+  , 3 --> "kilo"
+  , 6 --> "mega"
+  , 9 --> "giga"
+  , Any   (Error @@ "Something Else")
+  ]
+
 -- Compile-time tests
 
 _ = Refl :: UnitPrefix 0 :~: ""
 _ = Refl :: UnitPrefix 9 :~: "giga"
+
+_ = Refl :: Eval (UnitPrefix' 0) :~: ""
+_ = Refl :: Eval (UnitPrefix' 3) :~: "kilo"
 
 -- Dummy
 


### PR DESCRIPTION
Fixes #12 and adds `Case` FCF as simple and readable but less powerful alternative to `Guard`.