### PR TITLE
Draft adding Applicative, Monad and Traversable

### DIFF
--- a/first-class-families.cabal
+++ b/first-class-families.cabal
@@ -31,10 +31,13 @@ library
     Fcf.Data.List
     Fcf.Data.Nat
     Fcf.Data.Symbol
+    Fcf.Data.Tuple
     Fcf.Classes
     Fcf.Class.Bifunctor
     Fcf.Class.Foldable
     Fcf.Class.Functor
+    Fcf.Class.Applicative
+    Fcf.Class.Monad
     Fcf.Class.Monoid
     Fcf.Class.Monoid.Types
     Fcf.Class.Ord

--- a/first-class-families.cabal
+++ b/first-class-families.cabal
@@ -31,6 +31,7 @@ library
     Fcf.Data.List
     Fcf.Data.Nat
     Fcf.Data.Symbol
+    Fcf.Data.Traversable
     Fcf.Data.Tuple
     Fcf.Classes
     Fcf.Class.Bifunctor

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,70 @@
+{
+  description = "A library for type-level programming.";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    nix-filter.url = "github:numtide/nix-filter/main";
+  };
+
+  outputs = { self, nixpkgs, nix-filter }: 
+    let
+      pkgs = import nixpkgs { system = "x86_64-linux"; };
+
+      # filter = import nix-filter { };
+
+      ghcVersion = "925";
+      # ghcVersion = "92";
+      # ghcVersion = "902";
+
+      src = nix-filter.lib {
+        root = ./.;
+        include = [
+          (nix-filter.lib.inDirectory "src")
+          (nix-filter.lib.inDirectory "examples")
+          (nix-filter.lib.inDirectory "test")
+          (nix-filter.lib.matchExt "hs")
+          ./first-class-families.cabal
+          ./cabal.project
+          ./LICENSE
+        ];
+      };
+
+      first-class-families = hself: hself.callCabal2nix "first-class-families" src {};
+
+      myHaskellPackages = pkgs.haskell.packages."ghc${ghcVersion}".override {
+        overrides = hself: hsuper: {
+          first-class-families = first-class-families hself;
+          # ListLike = pkgs.haskell.lib.dontCheck hsuper.ListLike;
+          # type-of-html = pkgs.haskell.lib.doBenchmark (hself.callPackage ./nix/type-of-html.nix {inherit src;});
+          # type-of-html = hself.callCabal2nix "type-of-html" src {};
+          # optics-core = hsuper.optics-core.overrideAttrs(old: {
+          #   configureFlags = "-f explicit-generic-labels";
+          #   patches = [./optics-core.patch];
+          # });
+        };
+      };
+
+      shell = myHaskellPackages.shellFor {
+        packages = p: [
+          p.first-class-families
+        ];
+        buildInputs = with pkgs.haskell.packages."ghc${ghcVersion}"; [
+          myHaskellPackages.cabal-install
+          ghcid
+          (pkgs.haskell-language-server.override { supportedGhcVersions = [ "${ghcVersion}" ]; })
+          hlint
+          # implicit-hie
+          # cabal2nix
+        ];
+        withHoogle = true;
+        doBenchmark = true;
+      };
+
+    in
+      {
+        library = first-class-families;
+        # packages.x86_64-linux.default = ;
+        devShell.x86_64-linux = shell;
+        inherit pkgs;
+      };
+}

--- a/src/Fcf.hs
+++ b/src/Fcf.hs
@@ -40,18 +40,7 @@ module Fcf
 
     -- ** Functional combinators
 
-  , Pure
-  , Pure1
-  , Pure2
-  , Pure3
-  , type (=<<)
-  , type (<=<)
-  , LiftM
-  , LiftM2
-  , LiftM3
-  , Join
-  , type (<$>)
-  , type (<*>)
+  , type (.)
   , Flip
   , ConstFn
   , type ($)

--- a/src/Fcf/Class/Applicative.hs
+++ b/src/Fcf/Class/Applicative.hs
@@ -1,0 +1,224 @@
+{-# LANGUAGE
+    DataKinds,
+    PolyKinds,
+    TypeFamilies,
+    TypeOperators,
+    UndecidableInstances #-}
+
+{-|
+Module      : Fcf.Class.Applicative
+Description : Applicative definitions
+Copyright   : (c) gspia, 2020
+                  Skyfold, 2023
+License     : BSD
+Maintainer  : gspia
+
+= Fcf.Control.Applicative
+
+Provides a type level equivalent to Control.Applicative.
+
+The type class hierarchy is implicit (LiftA2 defined in terms of FMap and <*>).
+
+-}
+
+module Fcf.Class.Applicative
+  (
+  -- * Applicative functors
+    type (<*>)
+  , Pure
+  , LiftA2
+  -- , type (*>)
+  -- , type (<*)
+  -- * Alternatives
+  -- , Empty
+  -- , type (<|>)
+  -- , Some
+  -- , Many
+  -- * Instances
+  -- , Const
+  -- , WrappedMonad
+  -- , WrappedArrow
+  -- , ZipList
+  -- * Utility functions
+  -- , type (<$>)
+  -- , type (<$)
+  -- , type (<**>)
+  -- , LiftA
+  , LiftA3
+  , LiftA4
+  , LiftA5
+  -- , Optional
+  -- , Asum
+  , App2
+  , App3
+  , App4
+  , App5
+  ) where
+
+import           Data.Functor.Identity
+
+import Fcf (Exp, Eval, type (.))
+import Fcf.Class.Functor (FMap)
+import Fcf.Class.Monoid (type (<>), MEmpty)
+import Fcf.Data.List (type (++))
+import qualified Fcf.Combinators as C
+
+-- $setup
+-- >>> :set -XUndecidableInstances -XTypeInType -XGADTs
+-- >>> import Fcf.Core (Eval, Exp)
+-- >>> import Fcf.Data.Nat
+-- >>> import qualified GHC.TypeLits as TL
+-- >>> import qualified Fcf.Combinators as C
+
+
+--------------------------------------------------------------------------------
+-- Applicative
+
+-- | Applicative Pure.
+--
+-- :kind! Eval (Pure 1) :: Maybe Nat
+-- :kind! Eval (Pure 1) :: Either Symbol Nat
+data Pure :: a -> Exp (m a)
+type instance Eval (Pure a) = '[a]
+type instance Eval (Pure a) = 'Just a
+type instance Eval (Pure a) = 'Right a
+type instance Eval (Pure a) = 'Identity a
+type instance Eval (Pure a) = '(MEmpty, a)
+type instance Eval (Pure a) = '(MEmpty, MEmpty, a)
+type instance Eval (Pure a) = '(MEmpty, MEmpty, MEmpty, a)
+
+
+-- | (<*>) corresponds to the value level '<*>'. Note that this clashes with
+-- the definition given at Fcf.Combinators.((<*>)).
+--
+-- Applicatives that we define include:
+--
+--  - Identity
+--  - []
+--  - Maybe
+--  - Either
+--  - (,)
+--  - (,,)
+--  - (,,,)
+--
+-- === __Example__
+--
+-- >>> :kind! Eval ('Identity Plus2 <*> 'Identity 5)
+-- Eval ('Identity Plus2 <*> 'Identity 5) :: Identity Natural
+-- = 'Identity 7
+--
+-- >>> :kind! Eval ( (<*>) '[ (Fcf.+) 1, (Fcf.*) 10] '[4,5,6,7])
+-- Eval ( (<*>) '[ (Fcf.+) 1, (Fcf.*) 10] '[4,5,6,7]) :: [Natural]
+-- = '[5, 6, 7, 8, 40, 50, 60, 70]
+-- >>> :kind! Eval ( (<*>) '[ (Fcf.+) 1, (Fcf.*) 10] '[])
+-- Eval ( (<*>) '[ (Fcf.+) 1, (Fcf.*) 10] '[]) :: [Natural]
+-- = '[]
+-- >>> :kind! Eval ( (<*>) '[] '[4,5,6,7])
+-- Eval ( (<*>) '[] '[4,5,6,7]) :: [b]
+-- = '[]
+--
+--
+data (<*>) :: f (a -> Exp b) -> f a -> Exp (f b)
+
+type instance Eval ('Identity f <*> m) = Eval (FMap f m)
+
+type instance Eval ('[] <*> _) = '[]
+type instance Eval (_ <*> '[]) = '[]
+type instance Eval ((f ': fs) <*> (a ': as)) =
+    Eval ((++) (Eval (Star_ f (a ': as))) (Eval ((<*>) fs (a ':as))))
+
+-- Maybe
+type instance Eval ('Nothing <*> _) = 'Nothing
+type instance Eval ('Just f <*> m) = Eval (FMap f m)
+
+-- Either
+type instance Eval ('Left e <*> _) = 'Left e
+type instance Eval ('Right f <*> m) = Eval (FMap f m)
+
+-- | For tuples, the 'Monoid' constraint determines how the first values merge.
+-- For example, 'Symbol's concatenate:
+--
+-- >>> :kind! Eval ('("hello", (Fcf.+) 15) <*> '("world!", 2002))
+-- Eval ('("hello", (Fcf.+) 15) <*> '("world!", 2002)) :: (TL.Symbol,
+--                                                         Natural)
+-- = '("helloworld!", 2017)
+type instance Eval ('(u, f) <*> '(v, x)) = '(u <> v, Eval (f x))
+
+-- ((,,) a b)
+type instance Eval ('(a, b, f) <*> '(a', b', x)) = '(a <> a', b <> b', Eval (f x))
+
+-- ((,,,) a b)
+type instance Eval ('(a, b, c, f) <*> '(a', b', c', x)) = '(a <> a', b <> b', c <> c', Eval (f x))
+
+-- | Type level LiftA2.
+--
+-- === __Example__
+--
+-- >>> :kind! Eval (LiftA2 (Fcf.+) '[1,2] '[3,4])
+-- Eval (LiftA2 (Fcf.+) '[1,2] '[3,4]) :: [Natural]
+-- = '[4, 5, 5, 6]
+--
+--
+data LiftA2 :: (a -> b -> Exp c) -> f a -> f b -> Exp (f c)
+type instance Eval (LiftA2 f fa fb) = Eval (Eval (FMap (App2 f) fa) <*> fb)
+
+-- | Type level LiftA3.
+--
+-- === __Example__
+-- 
+-- >>> :kind! Eval (LiftA3 Tuple3 '[1,2] '[3,4] '[5,6])
+-- Eval (LiftA3 Tuple3 '[1,2] '[3,4] '[5,6]) :: [(Natural, Natural,
+--                                                Natural)]
+-- = '[ '(1, 3, 5), '(1, 3, 6), '(1, 4, 5), '(1, 4, 6), '(2, 3, 5),
+--      '(2, 3, 6), '(2, 4, 5), '(2, 4, 6)]
+--
+-- >>> :kind! Eval (LiftA3 Tuple3 ('Right 5) ('Right 6) ('Left "fail"))
+-- Eval (LiftA3 Tuple3 ('Right 5) ('Right 6) ('Left "fail")) :: Either
+--                                                                TL.Symbol (Natural, Natural, c)
+-- = 'Left "fail"
+--
+data LiftA3 :: (a -> b -> c -> Exp d) -> f a -> f b -> f c -> Exp (f d)
+type instance Eval (LiftA3 f fa fb fc) = Eval (Eval (Eval (FMap (App3 f) fa) <*> fb) <*> fc)
+
+-- | Type level LiftA4.
+data LiftA4 :: (a -> b -> c -> d -> Exp e) -> f a -> f b -> f c -> f d -> Exp (f e)
+type instance Eval (LiftA4 f fa fb fc fd) = Eval (Eval (Eval (Eval (FMap (App4 f) fa) <*> fb) <*> fc) <*> fd)
+
+-- | Type level LiftA5.
+data LiftA5 :: (a -> b -> c -> d -> e -> Exp g) -> f a -> f b -> f c -> f d -> f e -> Exp (f g)
+type instance Eval (LiftA5 f fa fb fc fd fe) = Eval (Eval (Eval (Eval (Eval (FMap (App5 f) fa) <*> fb) <*> fc) <*> fd) <*> fe)
+
+--------------------------------------------------------------------------------
+-- Helper Functions
+
+-- | Needed by LiftA2 instance to partially apply function
+data App2 :: (a -> b -> c) -> a -> Exp (b -> c)
+type instance Eval (App2 f a) = f a
+
+-- | Needed by LiftA3 instance to partially apply function
+data App3 :: (a -> b -> c -> d) -> a -> Exp (b -> Exp (c -> d))
+type instance Eval (App3 f a) = C.Pure2 f a
+
+-- | Needed by LiftA4 instance to partially apply function
+data App4 :: (a -> b -> c -> d -> e) -> a -> Exp (b -> Exp (c -> Exp (d -> e)))
+type instance Eval (App4 f a) = App3 (f a)
+
+-- | Needed by LiftA5 instance to partially apply function
+data App5 :: (a -> b -> c -> d -> e -> g) -> a -> Exp (b -> Exp (c -> Exp (d -> Exp (e -> g))))
+type instance Eval (App5 f a) = App4 (f a)
+
+-- | Helper for the [] applicative instance.
+data Star_ :: (a -> Exp b) -> f a -> Exp (f b)
+type instance Eval (Star_ _ '[]) = '[]
+type instance Eval (Star_ f (a ': as)) =
+    Eval (f a) ': Eval (Star_ f as)
+
+-- | Helper for 'FoldlM'
+data FoldlMHelper :: (b -> a -> Exp (m b)) -> a -> (b -> Exp (m b)) -> Exp (b -> Exp (m b))
+type instance Eval (FoldlMHelper f a b) = C.Flip (C.>>=) b . C.Flip f a
+
+-- | Helper for [] traverse
+data ConsHelper :: (a -> Exp (f b)) -> a -> f [b] -> Exp (f [b])
+type instance Eval (ConsHelper f x ys) = Eval (LiftA2 (C.Pure2 '(:)) (Eval (f x)) ys)
+-- The following would need an extra import line:
+-- type instance Eval (Cons_f f x ys) = Eval (LiftA2 Cons (Eval (f x)) ys)

--- a/src/Fcf/Class/Foldable.hs
+++ b/src/Fcf/Class/Foldable.hs
@@ -48,7 +48,7 @@ module Fcf.Class.Foldable
   ) where
 
 import Fcf.Core (Exp, Eval)
-import Fcf.Combinators (Pure, Pure1, type (<=<))
+import Fcf.Combinators (Pure, Pure1, type (.))
 import Fcf.Data.Function (Bicomap)
 import Fcf.Class.Monoid
 import Fcf.Class.Monoid.Types (Endo(..), UnEndo)
@@ -108,7 +108,7 @@ type FoldMapDefault_ f xs = Eval (Foldr (Bicomap f Pure (.<>)) MEmpty xs)
 -- >>> :kind! FoldrDefault_ (.<>) 'EQ '[ 'EQ, 'LT, 'GT ]
 -- FoldrDefault_ (.<>) 'EQ '[ 'EQ, 'LT, 'GT ] :: Ordering
 -- = 'LT
-type FoldrDefault_ f y xs = Eval (UnEndo (Eval (FoldMap (Pure1 'Endo <=< Pure1 f) xs)) y)
+type FoldrDefault_ f y xs = Eval (UnEndo (Eval (FoldMap (Pure1 'Endo . Pure1 f) xs)) y)
 
 -- | Right fold.
 --

--- a/src/Fcf/Class/Functor.hs
+++ b/src/Fcf/Class/Functor.hs
@@ -2,14 +2,15 @@
     DataKinds,
     PolyKinds,
     TypeFamilies,
-    TypeInType,
-    TypeOperators,
-    UndecidableInstances #-}
+    TypeOperators #-}
 
 module Fcf.Class.Functor
   ( Map
   , FMap
+  , type (<$>)
   ) where
+
+import Data.Functor.Identity
 
 import Fcf.Core (Exp, Eval)
 
@@ -36,6 +37,8 @@ data Map :: (a -> Exp b) -> f a -> Exp (f b)
 
 -- | Synonym of 'Map' to avoid name clashes.
 type FMap = Map
+type (<$>) = FMap
+infixl 1 <$>
 
 -- []
 type instance Eval (Map f '[]) = '[]
@@ -58,3 +61,6 @@ type instance Eval (Map f '(x, y, z, a)) =
   '(x, y, z, Eval (f a))
 type instance Eval (Map f '(x, y, z, w, a)) =
   '(x, y, z, w, Eval (f a))
+
+-- Identity
+type instance Eval (FMap f ('Identity a)) = 'Identity (Eval (f a))

--- a/src/Fcf/Class/Monad.hs
+++ b/src/Fcf/Class/Monad.hs
@@ -15,11 +15,11 @@ Maintainer  : gspia
 
 = Fcf.Control.Monad
 
-Provides a type level equivalent to Control.Monad and Data.Traversable. The 
-modules are merged since they both depend on the Monad typeclass. There is
+Provides a type level equivalent to Control.Monad and some of Data.Traversable. The 
+modules are merged for the parts that depend on the Monad typeclass. There is
 no way to specify a kind typeclass, so we cannot create a GHC.Base equivalent.
 
-The type class hierarchy is implicit (LiftA2 defined in terms of fmap and <*>).
+The type class hierarchy is implicit (>>= defined in terms of FMap and <*>).
 
 -}
 
@@ -36,7 +36,7 @@ module Fcf.Class.Monad
     -- * Funtions
     , MapM
     , ForM
-    , Sequence
+    -- , Sequence
     -- , type (=<<)
     -- , type (>=>)
     -- , type (<=<)
@@ -61,7 +61,7 @@ module Fcf.Class.Monad
     -- , Ap
     -- * The Traversable class
     , Traverse
-    -- , SequenceA
+    , SequenceA
     -- * Utility functions
     -- , For
     -- , MapAccumL
@@ -78,10 +78,10 @@ import           Data.Functor.Identity
 import           GHC.TypeNats as TN
 
 import           Fcf
-import qualified Fcf.Combinators as C
 import           Fcf.Class.Functor (FMap)
 import           Fcf.Class.Applicative
-import           Fcf.Data.Tuple
+import           Fcf.Data.Traversable
+import           Fcf.Data.Function (Id)
 
 --------------------------------------------------------------------------------
 
@@ -222,67 +222,7 @@ type instance Eval (FoldlM f z0 xs) = Eval ((Eval (Foldr (FoldlMHelper f) Return
 --------------------------------------------------------------------------------
 -- Traversable
 
-
--- | Traverse
---
--- === __Example__
---
--- >>> :kind! Eval (Traverse Id '[ '[1,2], '[3,4]])
--- Eval (Traverse Id '[ '[1,2], '[3,4]]) :: [[Natural]]
--- = '[ '[1, 3], '[1, 4], '[2, 3], '[2, 4]]
---
---
-data Traverse :: (a -> Exp (f b)) -> t a -> Exp (f (t b))
--- type instance Eval (Traverse f ta) = Eval (SequenceA =<< Map f ta)
--- Could the above one just be made to work? At the moment, the computation
--- diverges (we need to give the Traverse instances).
-
--- []
-type instance Eval (Traverse f lst) =
-    Eval (Foldr (ConsHelper f) (Eval (Return '[])) lst)
-
--- Maybe
-type instance Eval (Traverse f 'Nothing) = Eval (Return 'Nothing)
-type instance Eval (Traverse f ('Just x)) = Eval (FMap (C.Pure1 'Just) (Eval (f x)))
-
--- Either
-type instance Eval (Traverse f ('Left e)) = Eval (Return ('Left e))
-type instance Eval (Traverse f ('Right x)) = Eval (FMap (C.Pure1 'Right) (Eval (f x)))
-
--- ((,) a)
-type instance Eval (Traverse f '(x, y)) = Eval (FMap (Tuple2 x) (Eval (f y)))
-
-
--- | Sequence
---
--- === __Example__
---
--- >>> :kind! Eval (Sequence ('Just ('Right 5)))
--- Eval (Sequence ('Just ('Right 5))) :: Either a (Maybe Natural)
--- = 'Right ('Just 5)
---
--- >>> :kind! Eval (Sequence '[ 'Just 3, 'Just 5, 'Just 7])
--- Eval (Sequence '[ 'Just 3, 'Just 5, 'Just 7]) :: Maybe [Natural]
--- = 'Just '[3, 5, 7]
---
--- >>> :kind! Eval (Sequence '[ 'Just 3, 'Nothing, 'Just 7])
--- Eval (Sequence '[ 'Just 3, 'Nothing, 'Just 7]) :: Maybe [Natural]
--- = 'Nothing
---
--- >>> :kind! Eval (Sequence '[ '[1,2], '[3,4]])
--- Eval (Sequence '[ '[1,2], '[3,4]]) :: [[Natural]]
--- = '[ '[1, 3], '[1, 4], '[2, 3], '[2, 4]]
---
---
-data Sequence :: t (f a) -> Exp (f (t a))
-type instance Eval (Sequence tfa) = Eval (Traverse Id tfa)
-
---------------------------------------------------------------------------------
--- Utility
-
--- | Id function correspondes to term level 'id'-function.
-data Id :: a -> Exp a
-type instance Eval (Id a) = a
+type Sequence = SequenceA
 
 --------------------------------------------------------------------------------
 -- Helper Functions
@@ -290,13 +230,6 @@ type instance Eval (Id a) = a
 -- | Helper for 'FoldlM'
 data FoldlMHelper :: (b -> a -> Exp (m b)) -> a -> (b -> Exp (m b)) -> Exp (b -> Exp (m b))
 type instance Eval (FoldlMHelper f a b) = Flip (>>=) b . Flip f a
-
--- | Helper for [] traverse
-data ConsHelper :: (a -> Exp (f b)) -> a -> f [b] -> Exp (f [b])
-type instance Eval (ConsHelper f x ys) = Eval (LiftA2 (C.Pure2 '(:)) (Eval (f x)) ys)
--- The following would need an extra import line:
--- type instance Eval (Cons_f f x ys) = Eval (LiftA2 Cons (Eval (f x)) ys)
-
 
 --------------------------------------------------------------------------------
 -- For Examples

--- a/src/Fcf/Class/Monad.hs
+++ b/src/Fcf/Class/Monad.hs
@@ -1,0 +1,346 @@
+{-# LANGUAGE
+    DataKinds,
+    PolyKinds,
+    TypeFamilies,
+    TypeOperators,
+    UndecidableInstances #-}
+
+{-|
+Module      : Fcf.Class.Monad
+Description : Monad definitions
+Copyright   : (c) gspia, 2020
+                  Skyfold, 2023
+License     : BSD
+Maintainer  : gspia
+
+= Fcf.Control.Monad
+
+Provides a type level equivalent to Control.Monad and Data.Traversable. The 
+modules are merged since they both depend on the Monad typeclass. There is
+no way to specify a kind typeclass, so we cannot create a GHC.Base equivalent.
+
+The type class hierarchy is implicit (LiftA2 defined in terms of fmap and <*>).
+
+-}
+
+module Fcf.Class.Monad 
+    ( 
+    -- * Functor and monad classes
+      FMap
+    -- , type (<$)
+    , type (>>=)
+    , type (>>)
+    , Return
+    -- , MonadFail
+    -- , MonadPlus
+    -- * Funtions
+    , MapM
+    , ForM
+    , Sequence
+    -- , type (=<<)
+    -- , type (>=>)
+    -- , type (<=<)
+    -- , Void
+    -- * Generalisations of list functions 
+    -- , Join
+    -- , Msum
+    -- , Mfulter
+    -- , MapAndUnzipM
+    -- , ZipWithM
+    , FoldlM
+    -- , ReplicateM
+    -- * Conditional execution of monadic expressions 
+    -- , Guard
+    -- , When
+    -- , Unless
+    -- , LiftM
+    -- , LiftM2
+    -- , LiftM3
+    -- , LiftM4
+    -- , LiftM5
+    -- , Ap
+    -- * The Traversable class
+    , Traverse
+    -- , SequenceA
+    -- * Utility functions
+    -- , For
+    -- , MapAccumL
+    -- , MapAccumR
+    -- * General definitions for superclass methods
+    -- , FmapDefault
+    -- , FoldMapDefault
+    -- * Utility
+    , Id
+    )
+  where
+
+import           Data.Functor.Identity
+import           GHC.TypeNats as TN
+
+import           Fcf
+import qualified Fcf.Combinators as C
+import           Fcf.Class.Functor (FMap)
+import           Fcf.Class.Applicative
+import           Fcf.Data.Tuple
+
+--------------------------------------------------------------------------------
+
+-- For the doctests:
+
+-- $setup
+-- >>> import qualified GHC.TypeLits as TL
+-- >>> import qualified Fcf.Combinators as C
+
+--------------------------------------------------------------------------------
+-- Common methods for both Applicative and Monad
+
+
+-- | Return = Pure 
+--
+-- :kind! Eval (Return 1) :: Maybe Nat
+-- :kind! Eval (Return 1) :: Either Symbol Nat
+type Return = Pure
+
+--------------------------------------------------------------------------------
+-- Monad
+
+
+-- | Type level Bind corresponding to the value level bind '>>=' operator.
+--  Note that name (>>=) clashes with the definition given at
+--  Fcf.Combinators.(>>=). (It doesn't export it yet, though.)
+--
+-- Monads that we define include:
+--
+--  - Identity
+--  - []
+--  - Maybe
+--  - Either
+--  - (,)
+--  - (,,)
+--  - (,,,)
+--
+-- === __Example__
+--
+-- Example: double the length of the input list and increase the numbers at
+-- the same time.
+--
+-- >>> :kind! Eval ('[5,6,7] >>= Plus2M)
+-- Eval ('[5,6,7] >>= Plus2M) :: [Natural]
+-- = '[7, 8, 8, 9, 9, 10]
+--
+--
+-- >>> :kind! Eval (XsPlusYsMonadic '[1,2,3] '[4,5,6])
+-- Eval (XsPlusYsMonadic '[1,2,3] '[4,5,6]) :: [Natural]
+-- = '[5, 6, 7, 6, 7, 8, 7, 8, 9]
+data (>>=) :: m a -> (a -> Exp (m b)) -> Exp (m b)
+
+-- Maybe
+type instance Eval ('Nothing >>= f) = 'Nothing
+type instance Eval ('Just a >>= f) = Eval (f a)
+
+-- Either
+type instance Eval ('Left a >>= _) = 'Left a
+type instance Eval ('Right a >>= f) = Eval (f a)
+
+-- Identity
+type instance Eval ('Identity a >>= f) = Eval (f a)
+
+-- Lists
+type instance Eval ('[] >>= _) = '[]
+type instance Eval ((x ': xs) >>= f) = Eval ((f @@ x) ++  Eval (xs >>= f))
+
+-- (,)
+type instance Eval ('(u, a) >>= k) = Eval ('(u, Id) <*> Eval (k a))
+
+-- (,,)
+type instance Eval ('(u, v, a) >>= k) = Eval ('(u, v, Id) <*> Eval (k a))
+
+-- (,,,)
+type instance Eval ('(u, v, w, a) >>= k) = Eval ('(u, v, w, Id) <*> Eval (k a))
+
+-- | Type level >> 
+--
+-- === __Example__
+--
+--
+-- >>> :kind! Eval ( 'Just 1 >> 'Just 2)
+-- Eval ( 'Just 1 >> 'Just 2) :: Maybe Natural
+-- = 'Just 2
+-- >>> :kind! Eval ( 'Nothing >> 'Just 2)
+-- Eval ( 'Nothing >> 'Just 2) :: Maybe Natural
+-- = 'Nothing
+--
+data (>>) :: m a -> m b -> Exp (m b)
+type instance Eval (m >> k) = Eval (m >>= ConstFn k)
+
+--------------------------------------------------------------------------------
+-- MapM
+
+-- | MapM
+--
+-- === __Example__
+--
+-- >>> :kind! Eval (MapM (ConstFn '[ 'True, 'False]) '["a","b","c"])
+-- Eval (MapM (ConstFn '[ 'True, 'False]) '["a","b","c"]) :: [[Bool]]
+-- = '[ '[ 'True, 'True, 'True], '[ 'True, 'True, 'False],
+--      '[ 'True, 'False, 'True], '[ 'True, 'False, 'False],
+--      '[ 'False, 'True, 'True], '[ 'False, 'True, 'False],
+--      '[ 'False, 'False, 'True], '[ 'False, 'False, 'False]]
+--
+--
+data MapM :: (a -> Exp (m b)) -> t a -> Exp (m (t b))
+type instance Eval (MapM f ta) = Eval (Sequence (FMap f @@ ta))
+-- Above one is same as:
+-- type instance Eval (MapM f ta) = Eval (Sequence (Eval (Map f ta)))
+
+
+-- | ForM = Flip MapM
+data ForM :: t a -> (a -> Exp (m b)) -> Exp (m (t b))
+type instance Eval (ForM ta f) = Eval (MapM f ta)
+
+
+--------------------------------------------------------------------------------
+-- FoldlM
+
+-- | FoldlM
+--
+-- === __Example__
+--
+-- >>> import GHC.TypeLits as TL (Symbol, type (-))
+-- >>> data Lambda :: Nat -> Nat -> Exp (Either Symbol Natural)
+-- >>> type instance Eval (Lambda a b) = If (Eval (a >= b)) ('Right (a TL.- b)) ('Left "Nat cannot be negative")
+-- >>> :kind! Eval (FoldlM Lambda 5 '[1,1,1])
+-- Eval (FoldlM Lambda 5 '[1,1,1]) :: Either Symbol Natural
+-- = 'Right 2
+-- >>> :kind! Eval (FoldlM Lambda 5 '[1,4,1])
+-- Eval (FoldlM Lambda 5 '[1,4,1]) :: Either Symbol Natural
+-- = 'Left "Nat cannot be negative"
+--
+data FoldlM :: (b -> a -> Exp (m b)) -> b -> t a -> Exp (m b)
+type instance Eval (FoldlM f z0 xs) = Eval ((Eval (Foldr (FoldlMHelper f) Return xs)) z0)
+
+--------------------------------------------------------------------------------
+-- Traversable
+
+
+-- | Traverse
+--
+-- === __Example__
+--
+-- >>> :kind! Eval (Traverse Id '[ '[1,2], '[3,4]])
+-- Eval (Traverse Id '[ '[1,2], '[3,4]]) :: [[Natural]]
+-- = '[ '[1, 3], '[1, 4], '[2, 3], '[2, 4]]
+--
+--
+data Traverse :: (a -> Exp (f b)) -> t a -> Exp (f (t b))
+-- type instance Eval (Traverse f ta) = Eval (SequenceA =<< Map f ta)
+-- Could the above one just be made to work? At the moment, the computation
+-- diverges (we need to give the Traverse instances).
+
+-- []
+type instance Eval (Traverse f lst) =
+    Eval (Foldr (ConsHelper f) (Eval (Return '[])) lst)
+
+-- Maybe
+type instance Eval (Traverse f 'Nothing) = Eval (Return 'Nothing)
+type instance Eval (Traverse f ('Just x)) = Eval (FMap (C.Pure1 'Just) (Eval (f x)))
+
+-- Either
+type instance Eval (Traverse f ('Left e)) = Eval (Return ('Left e))
+type instance Eval (Traverse f ('Right x)) = Eval (FMap (C.Pure1 'Right) (Eval (f x)))
+
+-- ((,) a)
+type instance Eval (Traverse f '(x, y)) = Eval (FMap (Tuple2 x) (Eval (f y)))
+
+
+-- | Sequence
+--
+-- === __Example__
+--
+-- >>> :kind! Eval (Sequence ('Just ('Right 5)))
+-- Eval (Sequence ('Just ('Right 5))) :: Either a (Maybe Natural)
+-- = 'Right ('Just 5)
+--
+-- >>> :kind! Eval (Sequence '[ 'Just 3, 'Just 5, 'Just 7])
+-- Eval (Sequence '[ 'Just 3, 'Just 5, 'Just 7]) :: Maybe [Natural]
+-- = 'Just '[3, 5, 7]
+--
+-- >>> :kind! Eval (Sequence '[ 'Just 3, 'Nothing, 'Just 7])
+-- Eval (Sequence '[ 'Just 3, 'Nothing, 'Just 7]) :: Maybe [Natural]
+-- = 'Nothing
+--
+-- >>> :kind! Eval (Sequence '[ '[1,2], '[3,4]])
+-- Eval (Sequence '[ '[1,2], '[3,4]]) :: [[Natural]]
+-- = '[ '[1, 3], '[1, 4], '[2, 3], '[2, 4]]
+--
+--
+data Sequence :: t (f a) -> Exp (f (t a))
+type instance Eval (Sequence tfa) = Eval (Traverse Id tfa)
+
+--------------------------------------------------------------------------------
+-- Utility
+
+-- | Id function correspondes to term level 'id'-function.
+data Id :: a -> Exp a
+type instance Eval (Id a) = a
+
+--------------------------------------------------------------------------------
+-- Helper Functions
+
+-- | Helper for 'FoldlM'
+data FoldlMHelper :: (b -> a -> Exp (m b)) -> a -> (b -> Exp (m b)) -> Exp (b -> Exp (m b))
+type instance Eval (FoldlMHelper f a b) = Flip (>>=) b . Flip f a
+
+-- | Helper for [] traverse
+data ConsHelper :: (a -> Exp (f b)) -> a -> f [b] -> Exp (f [b])
+type instance Eval (ConsHelper f x ys) = Eval (LiftA2 (C.Pure2 '(:)) (Eval (f x)) ys)
+-- The following would need an extra import line:
+-- type instance Eval (Cons_f f x ys) = Eval (LiftA2 Cons (Eval (f x)) ys)
+
+
+--------------------------------------------------------------------------------
+-- For Examples
+
+-- | For Applicative documentation example
+data Plus1 :: Nat -> Exp Nat
+type instance Eval (Plus1 n) = n TN.+ 1
+
+-- | For Applicative documentation example
+data Plus2 :: Nat -> Exp Nat
+type instance Eval (Plus2 n) = n TN.+ 2
+
+-- | For the example. Turn an input number to list of two numbers of a bit
+-- larger numbers.
+data Plus2M :: Nat -> Exp [Nat]
+type instance Eval (Plus2M n) = '[n TN.+ 2, n TN.+3]
+
+-- | Part of an example
+data PureXPlusY :: Nat -> Nat -> Exp [Nat]
+type instance Eval (PureXPlusY x y) = Eval (Return ((TN.+) x y))
+
+-- | Part of an example
+data XPlusYs :: Nat -> [Nat] -> Exp [Nat]
+type instance Eval (XPlusYs x ys) = Eval (ys >>= PureXPlusY x)
+
+-- | An example implementing
+--
+-- sumM xs ys = do
+--     x <- xs
+--     y <- ys
+--     return (x + y)
+--
+-- or
+--
+-- sumM xs ys = xs >>= (\x -> ys >>= (\y -> pure (x+y)))
+--
+-- Note the use of helper functions. This is a bit awkward, a type level
+-- lambda would be nice.
+data XsPlusYsMonadic :: [Nat] -> [Nat] -> Exp [Nat]
+type instance Eval (XsPlusYsMonadic xs ys) = Eval (xs >>= Flip XPlusYs ys)
+
+-- data Sumnd :: [Nat] -> [Nat] -> Exp [Nat]
+-- type instance Eval (Sumnd xs ys) = xs >>=
+
+-- data Sum2 :: Nat -> Nat -> Exp Nat
+-- type instance Eval (Sum2 x y) = x TN.+ y
+

--- a/src/Fcf/Class/Monoid/Types.hs
+++ b/src/Fcf/Class/Monoid/Types.hs
@@ -14,7 +14,7 @@ module Fcf.Class.Monoid.Types
   ) where
 
 import Fcf.Core (Exp)
-import Fcf.Combinators (Pure, type (<=<))
+import Fcf.Combinators (Pure, type (.))
 import Fcf.Class.Monoid
 
 -- | Endofunctions.
@@ -34,5 +34,5 @@ type family UnEndo (e :: Endo a) :: a -> Exp a where
 --
 -- Note it is only a monoid up to 'Eval'.
 
-type instance 'Endo f <> 'Endo g = 'Endo (f <=< g)
+type instance 'Endo f <> 'Endo g = 'Endo (f . g)
 type instance MEmpty = 'Endo Pure

--- a/src/Fcf/Combinators.hs
+++ b/src/Fcf/Combinators.hs
@@ -15,7 +15,9 @@ module Fcf.Combinators
   , Pure2
   , Pure3
   , type (=<<)
+  , type (>>=)
   , type (<=<)
+  , type (.)
   , LiftM
   , LiftM2
   , LiftM3
@@ -34,6 +36,7 @@ import Fcf.Core
 infixl 1 >>=
 infixr 1 =<<, <=<
 infixl 4 <$>, <*>
+infixr 9 .
 
 data Pure :: a -> Exp a
 type instance Eval (Pure x) = x
@@ -54,7 +57,9 @@ data (>>=) :: Exp a -> (a -> Exp b) -> Exp b
 type instance Eval (e >>= k) = Eval (k (Eval e))
 
 data (<=<) :: (b -> Exp c) -> (a -> Exp b) -> a -> Exp c
-type instance Eval ((f <=< g) x) = Eval (f (Eval (g x)))
+type instance Eval ((f . g) x) = Eval (f (Eval (g x)))
+
+type (.) = (<=<)
 
 type LiftM = (=<<)
 

--- a/src/Fcf/Data/Function.hs
+++ b/src/Fcf/Data/Function.hs
@@ -11,6 +11,7 @@ module Fcf.Data.Function
   ( type (&)
   , On
   , Bicomap
+  , Id
   ) where
 
 import Fcf.Core
@@ -53,3 +54,7 @@ type instance Eval (On r f x y) = Eval (r (Eval (f x)) (Eval (f y)))
 -- = 'True
 data Bicomap :: (a -> Exp c) -> (b -> Exp d) -> (c -> d -> Exp e) -> a -> b -> Exp e
 type instance Eval (Bicomap f g r x y) = Eval (r (Eval (f x)) (Eval (g y)))
+
+-- | Id function correspondes to term level 'id'-function.
+data Id :: a -> Exp a
+type instance Eval (Id a) = a

--- a/src/Fcf/Data/List.hs
+++ b/src/Fcf/Data/List.hs
@@ -355,7 +355,7 @@ type instance Eval (Span p lst) = '( Eval (TakeWhile p lst), Eval (DropWhile p l
 -- Eval (Break (Flip (>) 9) '[1,2,3]) :: ([Nat], [Nat])
 -- = '( '[1, 2, 3], '[])
 data Break :: (a -> Exp Bool) -> [a] -> Exp ([a],[a])
-type instance Eval (Break p lst) = Eval (Span (Not <=< p) lst)
+type instance Eval (Break p lst) = Eval (Span (Not . p) lst)
 
 
 -- | List of suffixes of a list.
@@ -458,7 +458,7 @@ type instance Eval (Elem a as) = Eval (IsJust =<< FindIndex (TyEq a) as)
 -- | Find an element associated with a key in an association list.
 data Lookup :: k -> [(k, b)] -> Exp (Maybe b)
 type instance Eval (Lookup (a :: k) (as :: [(k, b)])) =
-  Eval (Map Snd (Eval (Find (TyEq a <=< Fst) as)) :: Exp (Maybe b))
+  Eval (Map Snd (Eval (Find (TyEq a . Fst) as)) :: Exp (Maybe b))
 
 
 -- | Find @Just@ the first element satisfying a predicate, or evaluate to

--- a/src/Fcf/Data/Traversable.hs
+++ b/src/Fcf/Data/Traversable.hs
@@ -1,0 +1,102 @@
+{-# LANGUAGE
+    DataKinds,
+    PolyKinds,
+    TypeFamilies,
+    TypeOperators,
+    UndecidableInstances #-}
+
+{-|
+Module      : Fcf.Data.Traversable
+Description : Class of data structures that can be traversed from left to right, performing an action on each element.
+Copyright   : (c) gspia, 2020
+                  Skyfold, 2023
+License     : BSD
+Maintainer  : gspia
+
+= Fcf.Data.Traversable
+
+Provides a type level equivalent to Data.Traversable without any Monad dependencise.
+
+The type class hierarchy is implicit (Traverse defined in terms of FMap and Foldr).
+
+-}
+
+module Fcf.Data.Traversable 
+    ( Traverse
+    , SequenceA
+    )
+  where
+
+-- import           Data.Functor.Identity
+
+import           Fcf
+import qualified Fcf.Combinators as C
+import           Fcf.Class.Functor (FMap)
+import           Fcf.Class.Applicative
+import           Fcf.Data.Tuple
+import           Fcf.Data.Function (Id)
+
+--------------------------------------------------------------------------------
+-- Traversable
+
+-- | Traverse
+--
+-- === __Example__
+--
+-- >>> :kind! Eval (Traverse Id '[ '[1,2], '[3,4]])
+-- Eval (Traverse Id '[ '[1,2], '[3,4]]) :: [[Natural]]
+-- = '[ '[1, 3], '[1, 4], '[2, 3], '[2, 4]]
+--
+--
+data Traverse :: (a -> Exp (f b)) -> t a -> Exp (f (t b))
+-- type instance Eval (Traverse f ta) = Eval (SequenceA =<< Map f ta)
+-- Could the above one just be made to work? At the moment, the computation
+-- diverges (we need to give the Traverse instances).
+
+-- []
+type instance Eval (Traverse f lst) =
+    Eval (Foldr (ConsHelper f) (Eval (Pure '[])) lst)
+
+-- Maybe
+type instance Eval (Traverse f 'Nothing) = Eval (Pure 'Nothing)
+type instance Eval (Traverse f ('Just x)) = Eval (FMap (C.Pure1 'Just) (Eval (f x)))
+
+-- Either
+type instance Eval (Traverse f ('Left e)) = Eval (Pure ('Left e))
+type instance Eval (Traverse f ('Right x)) = Eval (FMap (C.Pure1 'Right) (Eval (f x)))
+
+-- ((,) a)
+type instance Eval (Traverse f '(x, y)) = Eval (FMap (Tuple2 x) (Eval (f y)))
+
+-- | Sequence
+--
+-- === __Example__
+--
+-- >>> :kind! Eval (Sequence ('Just ('Right 5)))
+-- Eval (Sequence ('Just ('Right 5))) :: Either a (Maybe Natural)
+-- = 'Right ('Just 5)
+--
+-- >>> :kind! Eval (Sequence '[ 'Just 3, 'Just 5, 'Just 7])
+-- Eval (Sequence '[ 'Just 3, 'Just 5, 'Just 7]) :: Maybe [Natural]
+-- = 'Just '[3, 5, 7]
+--
+-- >>> :kind! Eval (Sequence '[ 'Just 3, 'Nothing, 'Just 7])
+-- Eval (Sequence '[ 'Just 3, 'Nothing, 'Just 7]) :: Maybe [Natural]
+-- = 'Nothing
+--
+-- >>> :kind! Eval (Sequence '[ '[1,2], '[3,4]])
+-- Eval (Sequence '[ '[1,2], '[3,4]]) :: [[Natural]]
+-- = '[ '[1, 3], '[1, 4], '[2, 3], '[2, 4]]
+--
+--
+data SequenceA :: t (f a) -> Exp (f (t a))
+type instance Eval (SequenceA tfa) = Eval (Traverse Id tfa)
+
+--------------------------------------------------------------------------------
+-- Helper Functions
+
+-- | Helper for [] traverse
+data ConsHelper :: (a -> Exp (f b)) -> a -> f [b] -> Exp (f [b])
+type instance Eval (ConsHelper f x ys) = Eval (LiftA2 (C.Pure2 '(:)) (Eval (f x)) ys)
+-- The following would need an extra import line:
+-- type instance Eval (Cons_f f x ys) = Eval (LiftA2 Cons (Eval (f x)) ys)

--- a/src/Fcf/Data/Tuple.hs
+++ b/src/Fcf/Data/Tuple.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE
+    DataKinds,
+    PolyKinds,
+    TypeFamilies,
+    UndecidableInstances #-}
+
+{-|
+Module      : Fcf.Data.Tuple
+Description : Type-level tuple functions
+Copyright   : (c) gspia 2020
+                  Skyfold, 2023
+License     : BSD
+Maintainer  : gspia
+
+= Fcf.Data.Tuple
+
+
+-}
+
+--------------------------------------------------------------------------------
+
+module Fcf.Data.Tuple where
+
+import           Fcf (Eval, Exp)
+
+--------------------------------------------------------------------------------
+
+-- For the doctests:
+
+-- $setup
+-- >>> import qualified GHC.TypeLits as TL
+
+--------------------------------------------------------------------------------
+
+-- | Swap
+--
+-- === __Example__
+--
+-- >>> :kind! Eval (Swap '(1, 2))
+-- Eval (Swap '(1, 2)) :: (TL.Natural, TL.Natural)
+-- = '(2, 1)
+data Swap :: (a, b) -> Exp (b, a)
+type instance Eval (Swap '(a,b)) = '(b,a)
+
+-- | 2-tuple to allow for partial application of 2-tuple at the type level
+data Tuple2 :: a -> b -> Exp (a, b)
+type instance Eval (Tuple2 a b) = '(a,b)
+
+-- | 3-tuple to allow for partial application of 3-tuple at the type level
+data Tuple3 :: a -> b -> c -> Exp (a, b, c)
+type instance Eval (Tuple3 a b c) = '(a,b,c)
+
+-- | 4-tuple to allow for partial application of 4-tuple at the type level
+data Tuple4 :: a -> b -> c -> d -> Exp (a, b, c, d)
+type instance Eval (Tuple4 a b c d) = '(a,b,c,d)
+
+-- | 5-tuple to allow for partial application of 4-tuple at the type level
+data Tuple5 :: a -> b -> c -> d -> e -> Exp (a, b, c, d, e)
+type instance Eval (Tuple5 a b c d e) = '(a,b,c,d,e)


### PR DESCRIPTION
This is a draft to give you an idea of the structure I am thinking of. It also contains the changes to `Fcf` that removes the exports of `Fcf.Combinators`. I left in the ones that won't class and renamed `<=<` to `.` (This was based on @gspia idea).

Let me know what you think.

Todo:
  - [ ] missing infixr for <*> and others
  - [ ] Applicative
    - [ ] Change type signatures so you can write `f <$> b <*> c <*>` style
    - [ ] Tests
    - [ ] Utility Functions
  - [ ] Monad
    - [ ] Change type signatures to compose nicely `a >> b >> c` and `a >>= f >>= f2` or `a >>= ((>>=) b . f)`
    - [ ] Tests
    - [ ] Utility Functions
  - [ ] Traversable
    - [ ] See if we want to change type signature
    - [ ] Add Monad dependency (needs to factor out `Fcf.Class.Monad` into `Fcf.Class.Monad.Internal`)
    - [ ] Tests
    - [ ] Utility Functions
